### PR TITLE
Refactor param converter configuration

### DIFF
--- a/spec/listeners/param_converter_listener_spec.cr
+++ b/spec/listeners/param_converter_listener_spec.cr
@@ -8,7 +8,7 @@ end
 
 describe ART::Listeners::ParamConverter do
   it "applies param converters related to the given route" do
-    converters = [MockParamConverter::Configuration.new("argument", MockParamConverter)] of ART::ParamConverterInterface::ConfigurationInterface
+    converters = [MockParamConverter::Configuration(Nil).new("argument", MockParamConverter)] of ART::ParamConverterInterface::ConfigurationInterface
     event = ART::Events::Action.new new_request, new_action param_converters: converters
 
     event.request.attributes.has?("argument").should be_false

--- a/spec/param_converter_interface_spec.cr
+++ b/spec/param_converter_interface_spec.cr
@@ -16,6 +16,18 @@ struct DefaultValueConverter < Athena::Routing::ParamConverterInterface
   def apply(request : ART::Request, configuration : Configuration) : Nil; end
 end
 
+struct SingleGenericConverter < Athena::Routing::ParamConverterInterface
+  configuration type_vars: T
+
+  def apply(request : ART::Request, configuration : Configuration) : Nil; end
+end
+
+struct MultipleGenericConverter < Athena::Routing::ParamConverterInterface
+  configuration type_vars: {A, B}
+
+  def apply(request : ART::Request, configuration : Configuration) : Nil; end
+end
+
 describe ART::ParamConverterInterface do
   describe ART::ParamConverterInterface::ConfigurationInterface do
     describe ".configuration" do
@@ -27,12 +39,20 @@ describe ART::ParamConverterInterface do
         TestConverter::Configuration.should eq TestConverter::Configuration
       end
 
+      it "allows defining a single custom generic argument" do
+        SingleGenericConverter::Configuration(Nil, Int32).should eq SingleGenericConverter::Configuration(Nil, Int32)
+      end
+
+      it "allows defining multiple custom generic arguments" do
+        MultipleGenericConverter::Configuration(Nil, Int32, String).should eq MultipleGenericConverter::Configuration(Nil, Int32, String)
+      end
+
       it "creates a configuration struct with the provided arguments" do
-        TestConverter::Configuration.new(value: 1, converter: TestConverter, name: "arg").value.should eq 1
+        TestConverter::Configuration(Nil).new(value: 1, converter: TestConverter, name: "arg").value.should eq 1
       end
 
       it "allows default values" do
-        DefaultValueConverter::Configuration.new(converter: DefaultValueConverter, name: "arg").enabled.should be_false
+        DefaultValueConverter::Configuration(Nil).new(converter: DefaultValueConverter, name: "arg").enabled.should be_false
       end
     end
   end

--- a/spec/parameter_bag_spec.cr
+++ b/spec/parameter_bag_spec.cr
@@ -115,12 +115,16 @@ describe ART::ParameterBag do
   end
 
   describe "#set" do
-    describe "with name and type" do
+    it "with name, type, and value" do
       ART::ParameterBag.new.set("value", "foo", String)
+    end
+
+    it "with name and value" do
+      ART::ParameterBag.new.set("value", "foo")
     end
   end
 
-  describe "#remove" do
+  it "#remove" do
     bag = ART::ParameterBag.new
     bag.set "value", "foo"
     bag.has?("value").should be_true

--- a/spec/time_converter_spec.cr
+++ b/spec/time_converter_spec.cr
@@ -2,7 +2,7 @@ require "./spec_helper"
 
 describe ART::TimeConverter do
   it "noops if the argument isn't within the request attributes" do
-    configuration = ART::TimeConverter::Configuration.new "time", ART::TimeConverter
+    configuration = ART::TimeConverter::Configuration(Time).new "time", ART::TimeConverter
     request = new_request
     request.attributes.has?("time").should be_false
 
@@ -14,7 +14,7 @@ describe ART::TimeConverter do
   it "retuurns the value as is if it's already a Time instance" do
     now = Time.utc
 
-    configuration = ART::TimeConverter::Configuration.new "time", ART::TimeConverter
+    configuration = ART::TimeConverter::Configuration(Time).new "time", ART::TimeConverter
     request = new_request
     request.attributes.set "time", now
 
@@ -24,7 +24,7 @@ describe ART::TimeConverter do
   end
 
   it "parses RFC 3339 by default" do
-    configuration = ART::TimeConverter::Configuration.new "time", ART::TimeConverter
+    configuration = ART::TimeConverter::Configuration(Time).new "time", ART::TimeConverter
     request = new_request
     request.attributes.set "time", "2020-04-07T12:34:56Z", String
 
@@ -34,7 +34,7 @@ describe ART::TimeConverter do
   end
 
   it "allows specifying a format" do
-    configuration = ART::TimeConverter::Configuration.new "time", ART::TimeConverter, format: "%Y--%m//%d  %T"
+    configuration = ART::TimeConverter::Configuration(Time).new "time", ART::TimeConverter, format: "%Y--%m//%d  %T"
     request = new_request
     request.attributes.set "time", "2020--04//07  12:34:56", String
 
@@ -44,7 +44,7 @@ describe ART::TimeConverter do
   end
 
   it "allows specifying a location to parse the format in" do
-    configuration = ART::TimeConverter::Configuration.new "time", ART::TimeConverter, format: "%Y--%m//%d  %T", location: Time::Location.load("Europe/Berlin")
+    configuration = ART::TimeConverter::Configuration(Time).new "time", ART::TimeConverter, format: "%Y--%m//%d  %T", location: Time::Location.load("Europe/Berlin")
     request = new_request
     request.attributes.set "time", "2020--04//07  12:34:56", String
 
@@ -54,7 +54,7 @@ describe ART::TimeConverter do
   end
 
   it "raises an ART::Exceptions::BadRequest if a time could not be parsed from the string" do
-    configuration = ART::TimeConverter::Configuration.new "time", ART::TimeConverter
+    configuration = ART::TimeConverter::Configuration(Time).new "time", ART::TimeConverter
     request = new_request
     request.attributes.set "time", "foo", String
 

--- a/src/parameter_bag.cr
+++ b/src/parameter_bag.cr
@@ -95,7 +95,7 @@ struct Athena::Routing::ParameterBag
   end
 
   # Sets a parameter with the provided *name* to *value*, restricted to the given *type*.
-  def set(name : String, value : _, type : T.class) : Nil forall T
+  def set(name : String, value : T, type : T.class) : Nil forall T
     @parameters[name] = Parameter(T).new value
   end
 

--- a/src/time_converter.cr
+++ b/src/time_converter.cr
@@ -32,7 +32,7 @@ struct Athena::Routing::TimeConverter < Athena::Routing::ParamConverterInterface
   configuration format : String? = nil, location : Time::Location = Time::Location::UTC
 
   # :inherit:
-  def apply(request : ART::Request, configuration : Configuration) : Nil
+  def apply(request : ART::Request, configuration : Configuration(_)) : Nil
     arg_name = configuration.name
 
     return unless request.attributes.has? arg_name


### PR DESCRIPTION
Expose the related action argument's type via generic
Allow defining additional generic types
Allow using a block to define additional methods
Fix type restriction on `ParameterBag`